### PR TITLE
Add Solana History Map to exploit resources

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,8 @@
 
 ## Solana Real-life Exploits and Hacks
 
+1. [Solana History Map](https://www.meow-woof.org) - Open-source, source-cited interactive atlas of Solana incidents, with playable teardowns of the Wormhole bridge verification failure, Mango oracle manipulation, and other incident mechanisms.
+
 ---
 
 ## Scanners and Tools


### PR DESCRIPTION
## Summary

- add Solana History Map to the currently empty Solana real-life exploits and hacks section
- describe it as an open-source, source-cited interactive incident resource

No other sections are changed.