### PR TITLE
Add mintcheck to Scanners and Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,7 @@
 1. Solana CTF Framework by Ottersec - (https://github.com/otter-sec/sol-ctf-framework)
 2. Solana CTF Challenges by Neodyme - (https://github.com/neodyme-labs/solana-ctf)
 3. Neodyme Workshop - (https://workshop.neodyme.io/)
+11. mintcheck (https://arijon13.github.io/mintcheck/) - Free SPL token rug-flag checker. Paste a mint and see whether the mint authority can still print supply and whether the freeze authority can freeze your tokens. Runs entirely in the browser against public RPC - no wallet, no signup, no backend. MIT licensed, source at https://github.com/arijon13/mintcheck
 
 
 ---


### PR DESCRIPTION
Adding **mintcheck**, a free SPL token rug-flag checker, alongside the other token-safety scanners in this section.

Paste a mint address and it reports the two authority risks that matter before you buy: whether the mint authority can still print more supply, and whether the freeze authority can freeze your tokens. It also flags holder concentration.

It runs entirely in the browser against public RPC — no wallet connect, no signup, no backend, nothing stored — so it is easy to verify what it does.

- Live: https://arijon13.github.io/mintcheck/
- Source (MIT): https://github.com/arijon13/mintcheck

Happy to reword or drop it if it is not a fit.